### PR TITLE
getRepos fixed

### DIFF
--- a/app/src/main/java/com/example/contribmontano/GithubService.kt
+++ b/app/src/main/java/com/example/contribmontano/GithubService.kt
@@ -9,6 +9,6 @@ data class Repository (
 )
 
 interface GithubService {
-    @GET("users/diego3g/repos/")
+    @GET("users/diego3g/repos")
     suspend fun getRepos(): Response<List<Repository>>
 }


### PR DESCRIPTION
A url estava incorreta. Com a correção da url, os repositórios são exibidos corretamente:

<img width="580" alt="Screenshot 2020-05-26 at 21 51 14" src="https://user-images.githubusercontent.com/10174890/82944316-42578280-9f9b-11ea-93f9-c905bd7a4492.png">

